### PR TITLE
Add <PreloadLink /> component

### DIFF
--- a/relay-modern/src/apps/artworks/components/Nav.js
+++ b/relay-modern/src/apps/artworks/components/Nav.js
@@ -1,17 +1,18 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
+import { PreloadLink } from 'lib/isomorphic-relay/PreloadLink'
 
 export default function Nav() {
   return (
     <ul>
       <li>
-        <Link to="/">Home</Link>
+        <PreloadLink to="/">Home</PreloadLink>
       </li>
       <li>
         <Link to="/about">About</Link>
       </li>
       <li>
-        <Link to="/artist/jean-michel-basquiat">Artist</Link>
+        <PreloadLink to="/artist/jean-michel-basquiat">Artist</PreloadLink>
       </li>
     </ul>
   )

--- a/relay-modern/src/apps/artworks/routes/artists/ArtistsRoute.js
+++ b/relay-modern/src/apps/artworks/routes/artists/ArtistsRoute.js
@@ -1,6 +1,6 @@
 import QueryLookupRenderer from 'relay-query-lookup-renderer'
 import React, { Component } from 'react'
-// import Artist from './Artist'
+import Artist from './Artist'
 import { graphql } from 'react-relay'
 import { getRelayEnvironment } from 'lib/isomorphic-relay/getRelayEnvironment'
 
@@ -32,7 +32,7 @@ export class ArtistsRoute extends Component {
           if (error) {
             return <div>{error.message}</div>
           } else if (props) {
-            return <div>basquiat</div>
+            return <Artist {...props} />
           } else {
             return <div>Loading</div>
           }

--- a/relay-modern/src/lib/isomorphic-relay/cache.js
+++ b/relay-modern/src/lib/isomorphic-relay/cache.js
@@ -1,0 +1,9 @@
+const cacheMap = new Map()
+
+export function set(key, value) {
+  cacheMap.set(key, value)
+}
+
+export function get(key) {
+  return cacheMap.get(key)
+}

--- a/relay-modern/src/lib/isomorphic-relay/mountClient.js
+++ b/relay-modern/src/lib/isomorphic-relay/mountClient.js
@@ -2,9 +2,12 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import { BrowserRouter } from 'react-router-dom'
 import { renderRoutes } from 'react-router-config'
+import * as cache from './cache'
 
 export function mountClient(routes, mountId) {
   const { relay } = JSON.parse(window.__BOOTSTRAP__)
+
+  cache.set(window.location.pathname, relay.response)
 
   ReactDOM.hydrate(
     <BrowserRouter>{renderRoutes(routes, relay)}</BrowserRouter>,

--- a/relay-modern/src/lib/isomorphic-relay/mountServer.js
+++ b/relay-modern/src/lib/isomorphic-relay/mountServer.js
@@ -36,8 +36,6 @@ export function mountServer(routes, getComponent) {
         },
       }
 
-      // console.log(response)
-
       const IsomorphicRelayRouter = ({ children, routerProps }) => {
         return (
           <Fragment>


### PR DESCRIPTION
Fetches route data before the page transitions and is a drop-in replacement for react-router's Link component. 